### PR TITLE
fix(a2a3): drain only pending TPipe credits

### DIFF
--- a/include/pto/npu/a2a3/TPush.hpp
+++ b/include/pto/npu/a2a3/TPush.hpp
@@ -61,10 +61,7 @@ struct TPipe {
         return (tileIndex % SyncPeriod) == 0;
     }
 
-    PTO_INTERNAL static bool shouldNotifyFree(uint32_t tileIndex)
-    {
-        return ((tileIndex + 1) % SyncPeriod) == 0;
-    }
+    PTO_INTERNAL static bool shouldNotifyFree(uint32_t tileIndex) { return ((tileIndex + 1) % SyncPeriod) == 0; }
 
     struct Producer {
         uint32_t tileIndex = 0;
@@ -482,7 +479,20 @@ struct TPipe {
     // Initial TPUSH calls skip allocate() via shouldWaitFree (tileIndex < SlotNum, or 0 for depth 1).
     PTO_INTERNAL ~TPipe()
     {
-        for (uint32_t i = 0; i < SyncPeriod; ++i) {
+        const uint32_t numPopFree = prod.tileIndex / SyncPeriod;
+        uint32_t numPushWait = 0;
+        if constexpr (SlotNum == 1) {
+            numPushWait = (prod.tileIndex > 0) ? prod.tileIndex - 1 : 0;
+        } else if (prod.tileIndex > SlotNum) {
+            constexpr uint32_t firstAligned =
+                (SlotNum % SyncPeriod == 0) ? SlotNum : ((SlotNum / SyncPeriod) + 1) * SyncPeriod;
+            const uint32_t lastAligned = ((prod.tileIndex - 1) / SyncPeriod) * SyncPeriod;
+            if (lastAligned >= firstAligned) {
+                numPushWait = (lastAligned - firstAligned) / SyncPeriod + 1;
+            }
+        }
+        const uint32_t drainCount = (numPopFree > numPushWait) ? (numPopFree - numPushWait) : 0;
+        for (uint32_t i = 0; i < drainCount; ++i) {
             prod.allocate();
         }
     }


### PR DESCRIPTION
## Summary

### 1. 修复 A2/A3 `TPipe` 析构阶段过量等待 free credit

#### 为什么要改

PyPTO 更新到包含新版 PTO-ISA 的 runtime 后，Qwen3 scope-3 prefill 已经能够完成编译，但在 A2/A3 真机执行阶段出现 scheduler stall：设备侧只剩一个 task 处于 `running-stalled`，其余大量 task 均在等待，最终由 ACL 返回 `507018`。这说明当前阻塞已经不在 PyPTO/pypto-lib 的编译接口或 soft-sync API，而是在 PTO-ISA A2/A3 `TPipe` 的跨核 FIFO 同步协议中。

`TPipe` 用 flag credit 协调生产者 `TPUSH` 与消费者 `TFREE`：

- 消费者每处理 `SyncPeriod` 个 tile，通过 `shouldNotifyFree()` 发出一个 free credit；
- 生产者填满启动窗口后，通过 `shouldWaitFree()` 消费 credit，确认 FIFO 已腾出空间；
- pipe 结束时，析构函数需要清理尚未被 `TPUSH` 消费的剩余 credit，避免同一 flag 后续复用时带入旧状态。

旧析构函数无论本次 pipe 实际产生了多少 credit、`TPUSH` 已经消费了多少 credit，都会固定执行 `SyncPeriod` 次 `prod.allocate()`。这会把已经被 `TPUSH` 消费过的 credit 再等待一次；当剩余 credit 少于 `SyncPeriod` 时，析构函数会等待一个永远不会再到达的通知，最终把设备 core 卡住。

#### 根因的具体计算

Qwen 失败路径中的参数为 `SlotNum = 8`、`SyncPeriod = 4`，共执行 40 次 push：

| 项目 | 计算方式 | 数量 |
| --- | --- | ---: |
| `TFREE` 已发出的 credit | `40 / 4` | 10 |
| 稳态 `TPUSH` 已消费的 credit | 在 tile index `8, 12, ..., 36` 等待 | 8 |
| 析构时真正剩余的 credit | `10 - 8` | 2 |
| 旧析构函数固定等待 | `SyncPeriod` | 4 |

因此前两次析构等待能够消费剩余 credit，第三次等待已经没有对应的 `TFREE` 通知，core 会永久阻塞。设备日志中的 scheduler stall 正是这一 credit 账本失配的结果。

#### 怎么改

析构函数不再固定等待 `SyncPeriod` 次，而是根据本次 pipe 的实际 `prod.tileIndex` 重新核算 credit：

1. 用 `numPopFree = prod.tileIndex / SyncPeriod` 计算消费者已经发出的 free credit 数量。
2. 复用 `TPUSH` 的启动窗口和周期规则，计算生产阶段已经执行的等待次数 `numPushWait`：
   - `SlotNum == 1` 时，第一次 push 不等待，之后每次 push 都等待，因此为 `prod.tileIndex - 1`；
   - 其他深度从不小于 `SlotNum` 的第一个 `SyncPeriod` 对齐点开始，统计到最后一次 push 之前的所有对齐等待点。
3. 计算 `drainCount = max(numPopFree - numPushWait, 0)`，析构函数只调用 `prod.allocate()` `drainCount` 次。

在上述 Qwen 例子中，新逻辑得到 `drainCount = 10 - 8 = 2`，恰好清理两个残余 credit，不会再凭空多等待两次。`max(..., 0)` 同时避免无符号下溢；`SlotNum == 1` 单独处理，是为了保持 depth-1 FIFO“首个 push 不等待”的既有启动语义。

#### 修改范围

- 只修改 `include/pto/npu/a2a3/TPush.hpp` 中 A2/A3 `TPipe` 的析构 drain 逻辑。
- 不修改 credit 的发送周期、正常 `TPUSH` 的等待条件、FIFO 数据布局或 soft-sync 接口。
- 不影响 CPU-SIM；CPU-SIM 的 V2C `LEFT_RIGHT` GM 布局问题由独立的 #241 处理。

### 2. 为什么该修改能够解决 PyPTO 阻塞

这次修改让析构清理严格等于“消费者已发出但生产者尚未消费”的 credit 数，而不是用 FIFO 的同步周期猜测剩余量。这样既能清空本次 pipe 的残余 flag 状态，又不会等待不存在的 credit，因此后续复用该 flag 的 pipeline 不会再因前一条 pipe 的账本失配而停住。

## Validation

- `pre-commit run --all-files`：通过。
- A2/A3 CCE 编译现有 `tpushpop_vc` kernel：通过。
- PyPTO Qwen3 scope-3 混合 A2/A3 上板：device 5 单次执行 1/1 通过。
- 同一上板用例连续执行三次：3/3 通过。
- 对 `SlotNum = 1..64`、transfer count `= 0..1024` 做 credit 账本穷举，并与逐步模拟 `shouldNotifyFree()` / `shouldWaitFree()` 的结果比较：全部精确一致。
- 上板任务：`task_20260811_053533_149780531`。

## 当前 CI 状态说明

- Pre-commit、Docs、CPU SIM smoke、CPU SIM full ST 均通过。
- A5 Smoke 的红灯发生在 checkout 阶段：runner 三次拉取 PR commit 都因 GitHub 网络超时失败，尚未进入编译或测试，因此不是本修改触发的代码失败。该 PR 保持 Draft，暂不推进评审。
