### PR TITLE
fix(cpu-sim): preserve V2C left-right GM layout

### DIFF
--- a/include/pto/cpu/TPush.hpp
+++ b/include/pto/cpu/TPush.hpp
@@ -967,11 +967,18 @@ PTO_INTERNAL void TPush_gm(Pipe& pipe, TileProd& tile, size_t entryBase)
     using SrcT = typename TileProd::DType;
     constexpr int rows = TileProd::Rows;
     constexpr int cols = TileProd::Cols;
+    constexpr bool isSplitV2CProducer =
+        Pipe::is_v2c && cpu_pipe::IsV2CProducerTile<TileProd>() && Split != TileSplitAxis::TILE_NO_SPLIT;
+    constexpr int gmStrideR = (isSplitV2CProducer && Split == TileSplitAxis::TILE_LEFT_RIGHT) ? cols * 2 : cols;
     std::size_t subOffset = 0;
-    if constexpr (Split != TileSplitAxis::TILE_NO_SPLIT) {
+    if constexpr (isSplitV2CProducer && Split == TileSplitAxis::TILE_UP_DOWN) {
+        subOffset = static_cast<std::size_t>(get_subblockid()) * rows * cols * sizeof(DstT);
+    } else if constexpr (isSplitV2CProducer && Split == TileSplitAxis::TILE_LEFT_RIGHT) {
+        subOffset = static_cast<std::size_t>(get_subblockid()) * cols * sizeof(DstT);
+    } else if constexpr (Split != TileSplitAxis::TILE_NO_SPLIT) {
         subOffset = static_cast<std::size_t>(get_subblockid()) * rows * cols * sizeof(DstT);
     }
-    using GlobalData = GlobalTensor<DstT, Shape<1, 1, 1, rows, cols>, Stride<1, 1, 1, cols, 1>>;
+    using GlobalData = GlobalTensor<DstT, Shape<1, 1, 1, rows, cols>, Stride<1, 1, 1, gmStrideR, 1>>;
     auto* addr = reinterpret_cast<__gm__ DstT*>(
         reinterpret_cast<std::uintptr_t>(pipe.fifo.GM_SLOT_BUFFER) + entryBase + subOffset);
     if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT) {

--- a/tests/cpu/st/testcase/tpushpop/main.cpp
+++ b/tests/cpu/st/testcase/tpushpop/main.cpp
@@ -181,6 +181,56 @@ void testDirBothConsumerWaitsForMatchingDirection()
         TFREE<Pipe, SplitAxis>(vecConsumer1);
     }
 }
+
+template <TileSplitAxis SplitAxis, uint8_t FlagId>
+void testGmFifoPreservesV2CSplitLayout()
+{
+    using VecTile = DirBothVecTile<SplitAxis>;
+    using MatTile = Tile<TileType::Mat, float, 16, 16, BLayout::RowMajor, 16, 16>;
+    using Pipe = TPipe<FlagId, Direction::DIR_V2C, sizeof(float) * MatTile::Numel, 2>;
+
+    std::vector<float> fifoStorage(MatTile::Numel * Pipe::RingFiFo::SLOT_NUM, 0.0f);
+    Pipe::reset_for_cpu_sim();
+    Pipe producer0(fifoStorage.data(), 0x0, 0x10000);
+    Pipe producer1(fifoStorage.data(), 0x0, 0x10000);
+    Pipe consumer(fifoStorage.data(), 0x0, 0x10000);
+
+    VecTile src0;
+    VecTile src1;
+    MatTile dst;
+    TASSIGN(src0, 0x0);
+    TASSIGN(src1, VecTile::GetSizeInBytes());
+    TASSIGN(dst, 2 * VecTile::GetSizeInBytes());
+    fillTileSequence(src0, 1.0f);
+    fillTileSequence(src1, 1001.0f);
+    std::fill(dst.data(), dst.data() + dst.Numel, 0.0f);
+
+    {
+        cpu_sim::ScopedExecutionContext ctx(0, 0, 2);
+        TPUSH<Pipe, VecTile, SplitAxis>(producer0, src0);
+    }
+    {
+        cpu_sim::ScopedExecutionContext ctx(0, 1, 2);
+        TPUSH<Pipe, VecTile, SplitAxis>(producer1, src1);
+    }
+    {
+        cpu_sim::ScopedExecutionContext ctx(0, 0, 1);
+        TPOP<Pipe, MatTile, SplitAxis>(consumer, dst);
+        TFREE<Pipe, SplitAxis>(consumer);
+    }
+
+    for (int r = 0; r < dst.GetValidRow(); ++r) {
+        for (int c = 0; c < dst.GetValidCol(); ++c) {
+            const int lane = (SplitAxis == TileSplitAxis::TILE_UP_DOWN) ? r / VecTile::Rows : c / VecTile::Cols;
+            const int laneRow = (SplitAxis == TileSplitAxis::TILE_UP_DOWN) ? r % VecTile::Rows : r;
+            const int laneCol = (SplitAxis == TileSplitAxis::TILE_LEFT_RIGHT) ? c % VecTile::Cols : c;
+            const auto& src = (lane == 0) ? src0 : src1;
+            EXPECT_FLOAT_EQ(
+                dst.data()[GetTileElementOffset<MatTile>(r, c)],
+                src.data()[GetTileElementOffset<VecTile>(laneRow, laneCol)]);
+        }
+    }
+}
 } // namespace
 
 template <typename T, int rows, int cols, TileType srcLoc>
@@ -482,6 +532,12 @@ TEST_F(TPushPopTest, v2c_split_with_injected_pipe_hook_waits_for_both_lanes_befo
     EXPECT_GT(g_pipe_hook_call_count.load(std::memory_order_relaxed), 0u);
     EXPECT_EQ(g_pipe_hook_size, sizeof(HookedV2CPipe::SharedStateStorage));
     EXPECT_NE(g_pipe_hook_last_key, 0u);
+}
+
+TEST_F(TPushPopTest, v2c_gm_fifo_preserves_updown_and_leftright_layout)
+{
+    testGmFifoPreservesV2CSplitLayout<TileSplitAxis::TILE_UP_DOWN, 10>();
+    testGmFifoPreservesV2CSplitLayout<TileSplitAxis::TILE_LEFT_RIGHT, 11>();
 }
 
 TEST_F(TPushPopTest, a5_style_dir_both_updown_waits_for_matching_direction)


### PR DESCRIPTION
## Summary

### 1. 修复 CPU-SIM 中 V2C `LEFT_RIGHT` 写入真实 GM FIFO 时的数据布局

#### 为什么要改

PyPTO 的 `system-tests-a5sim` 中，A5 路径能够通过，失败集中在 A2A3sim 的两条 `LEFT_RIGHT` 用例：

- `test_tpush_tpop_v2c_leftright[a2a3sim]`
- `test_tpop_bidirect_leftright[a2a3sim]`

失败表现为 cube consumer 读出的矩阵与预期左右拼接结果不一致；同一套用例中的 `UP_DOWN` 和 `NO_SPLIT` 正常。A2A3sim 走的是 PTO-ISA `include/pto/cpu/TPush.hpp`，因此这不是 A5 device 问题，也不是新版 soft-sync 接口问题，而是 PTO-ISA CPU-SIM 对 V2C split tile 的 GM 布局模拟错误。

#### 根因

回归由 `d07bd4b69f4555d9cad12a0e3569975d5b205fe3`（`[CPU-SIM] TPUSH fix pipe feature`）引入。该重构把原来的 V2C 专用 GM 写入逻辑合并到通用 `TPush_gm` 后，对所有非 `NO_SPLIT` 情况统一使用了下面的布局：

- lane 偏移：`lane * rows * cols * sizeof(DstT)`
- GM 行 stride：`cols`

这个布局只适用于 `UP_DOWN`，因为两个 lane 在目标矩阵中确实是前后两个连续的行块；它不适用于 `LEFT_RIGHT`，因为 `LEFT_RIGHT` 的两个 lane 应该在目标矩阵的每一行内左右相邻。

两种 split 的正确布局分别是：

| Split | lane 0 起始偏移 | lane 1 起始偏移 | GM 行 stride | 最终矩阵 |
| --- | ---: | ---: | ---: | --- |
| `UP_DOWN` | `0` | `rows * cols * sizeof(DstT)` | `cols` | `(2 * rows) x cols` |
| `LEFT_RIGHT` | `0` | `cols * sizeof(DstT)` | `2 * cols` | `rows x (2 * cols)` |

旧实现把 `LEFT_RIGHT` 的 lane 1 放到了 lane 0 整块数据之后，并且每写完一行只前进 `cols` 个元素。结果不是逐行的 `[lane0 row][lane1 row]`，而是两个连续块；cube consumer 按 `rows x (2 * cols)` 读取时自然得到错误矩阵。

#### 怎么改

在 `TPush_gm` 中先用编译期条件限定真正需要 split V2C 布局的路径：

```cpp
Pipe::is_v2c &&
cpu_pipe::IsV2CProducerTile<TileProd>() &&
Split != TileSplitAxis::TILE_NO_SPLIT
```

其中 `IsV2CProducerTile<TileProd>()` 只匹配 Vec producer；`Pipe::is_v2c` 也覆盖 `DIR_BOTH` 中的 V2C 方向。随后按 split axis 分别计算布局：

1. `UP_DOWN` 保持原有行为：lane 1 偏移一个完整的 `rows x cols` tile，行 stride 仍为 `cols`。
2. `LEFT_RIGHT` 将行 stride 改为 `2 * cols`，lane 1 只偏移 `cols * sizeof(DstT)`，从每一行的右半部分开始写。
3. 其他 split producer 继续走原有 fallback；`NO_SPLIT` 仍走已有的线性复制/量化路径。

这样修改后，两个 V2C lane 会写入同一个目标矩阵的正确子窗口：`UP_DOWN` 写上下半区，`LEFT_RIGHT` 写左右半区。

#### 为什么需要限制生效条件

通用 `TPush_gm` 同时服务多种 tile 和方向。如果只根据 `Split` 改 stride，会连带改变 C2V Acc/Mat producer 以及其他 fixpipe 路径的既有布局。把新规则限制为“V2C + Vec producer + split”后：

- C2V producer 不变；
- Acc/Mat producer 不变；
- `NO_SPLIT` 的 fixpipe、转换和量化行为不变；
- `DIR_BOTH` 仅在其中的 V2C Vec producer 路径获得正确布局。

### 2. 增加覆盖真实 GM FIFO 的 V2C split 回归测试

#### 为什么要增加测试

已有 CPU-SIM 测试主要传入空的 `GM_SLOT_BUFFER`，覆盖的是 CPU-SIM local slot storage 路径；本次 bug 位于 `GM_SLOT_BUFFER != nullptr` 时调用的 `TPush_gm`。因此旧测试即使全部通过，也无法发现或防止这类 GM stride/offset 回归。

#### 怎么改

在已注册到 CPU CI 的 `tpushpop` 测试中新增一个使用非空 `fifoStorage.data()` 的用例：

1. 创建两个 V2C producer，分别模拟 vector lane 0 和 lane 1，并写入起始值不同的序列，确保两块数据可区分。
2. 使用 cube consumer 从同一个真实 GM FIFO slot 中 `TPOP` 出完整的 `16 x 16` Mat tile。
3. 对结果逐元素校验，同时覆盖：
   - `UP_DOWN`：两个 `8 x 16` Vec tile 拼成 `16 x 16`；
   - `LEFT_RIGHT`：两个 `16 x 8` Vec tile 拼成 `16 x 16`。

该测试在移除实现修复时会稳定暴露 `LEFT_RIGHT` 布局错误，恢复修复后通过，因此能够直接保护本次修改对应的 GM 写入分支。

### 3. 修改范围与 #240 的关系

- 本 PR 只修改 CPU-SIM 的 V2C split GM 写入布局及其回归测试。
- 不修改 A2/A3 device 实现，也不修改 soft-sync API。
- #240 处理 A2/A3 真机 `TPipe` 析构时的 pending-credit drain；本 PR 处理 A2A3sim 的 `LEFT_RIGHT` 数据布局。二者是 PyPTO #2273 暴露出的两个相互独立的 PTO-ISA 阻塞项。

## Validation

- Red/Green：移除实现修复后，新增测试的 `LEFT_RIGHT` 分支失败；恢复修复后通过。
- PTO-ISA CPU-SIM `tpushpop`：16/16 通过。
- PyPTO 两条 A2A3sim `LEFT_RIGHT` 定向用例：2/2 通过。
- `pre-commit run --all-files`：通过。
- `git diff --check`：通过。
- PR 远端 CI：Pre-commit、Docs、CPU SIM smoke、CPU SIM full ST、A5 Smoke 共 5 项全部通过。

该 PR 保持 Draft，暂不推进评审。
