### PR TITLE
fix(a5): restore local pipe credits and TScatter ordering

### DIFF
--- a/include/pto/npu/a5/TPop.hpp
+++ b/include/pto/npu/a5/TPop.hpp
@@ -33,7 +33,12 @@ PTO_INTERNAL std::enable_if_t<is_tile_data_v<TileCons>, void> TPOP_IMPL(Pipe& pi
     }
 
     // 2. Address Calculation & Pop
-    bool reqFree = pipe.cons.template pop<TileCons, Split>(pipe.fifo, tile, get_subblockid());
+    bool reqFree;
+    if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT) {
+        reqFree = pipe.cons.template pop<TileCons, Split>(pipe.fifo, tile, 0);
+    } else {
+        reqFree = pipe.cons.template pop<TileCons, Split>(pipe.fifo, tile, get_subblockid());
+    }
 
     // 3. Cross-Core: Free Space
     bool isFree =

--- a/include/pto/npu/a5/TPush.hpp
+++ b/include/pto/npu/a5/TPush.hpp
@@ -724,7 +724,11 @@ PTO_INTERNAL void TPUSH_IMPL(Pipe& pipe, TileProd& tile)
     }
 
     // 2. Address Calculation
-    pipe.prod.template push<TileProd, Split>(pipe.fifo, tile, get_subblockid());
+    if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT) {
+        pipe.prod.template push<TileProd, Split>(pipe.fifo, tile, 0);
+    } else {
+        pipe.prod.template push<TileProd, Split>(pipe.fifo, tile, get_subblockid());
+    }
     pipe.prod.tileIndex++;
 
     // 3. Cross-Core: Commit & Signal

--- a/include/pto/npu/a5/TPush.hpp
+++ b/include/pto/npu/a5/TPush.hpp
@@ -42,6 +42,10 @@ struct TPipe {
     static constexpr bool is_v2c = is_v2c_gm || is_v2c_mat || is_v2c_ctrl;
     static_assert(
         is_c2v || is_v2c || is_both || is_both_gm, "Fix: TPipe only supports C2V or V2C or Both communication on A5.");
+    // Local no-split FIFOs get their initial capacity from shouldWaitFree's startup window.
+    // GM and split FIFOs use the explicit constructor/destructor credit protocol below.
+    static constexpr bool uses_local_no_split_credit_protocol =
+        IsNoSplit && (is_c2v_ub || is_v2c_mat || is_v2c_ctrl || is_both);
     static constexpr uint8_t VEC_CORE_ID_OFFSET = 16;
     static_assert(
         FlagIDPlusOne < 16, "Fix: With Both direction, FlagID + 1 must be less than 16 due to hardware limit.");
@@ -685,11 +689,13 @@ struct TPipe {
     PTO_INTERNAL explicit TPipe(__gm__ void* GM_SLOT_BUFFER, uint32_t C2V_CONSUMER_BUF, uint32_t V2C_CONSUMER_BUF)
         : fifo(GM_SLOT_BUFFER, C2V_CONSUMER_BUF, V2C_CONSUMER_BUF), prod(), cons()
     {
-        for (uint32_t i = 0; i < SyncPeriod; ++i) {
-            if constexpr (IsNoSplit) {
-                cons.template free<TileSplitAxis::TILE_NO_SPLIT>();
-            } else {
-                cons.template free<TileSplitAxis::TILE_UP_DOWN>();
+        if constexpr (!uses_local_no_split_credit_protocol) {
+            for (uint32_t i = 0; i < SyncPeriod; ++i) {
+                if constexpr (IsNoSplit) {
+                    cons.template free<TileSplitAxis::TILE_NO_SPLIT>();
+                } else {
+                    cons.template free<TileSplitAxis::TILE_UP_DOWN>();
+                }
             }
         }
     }
@@ -697,11 +703,30 @@ struct TPipe {
     // Destructor for TPipe
     PTO_INTERNAL ~TPipe()
     {
-        for (uint32_t i = 0; i < SyncPeriod; ++i) {
-            if constexpr (IsNoSplit) {
+        if constexpr (uses_local_no_split_credit_protocol) {
+            const uint32_t numPopFree = prod.tileIndex / SyncPeriod;
+            uint32_t numPushWait = 0;
+            if constexpr (SlotNum == 1) {
+                numPushWait = (prod.tileIndex > 0) ? prod.tileIndex - 1 : 0;
+            } else if (prod.tileIndex > SlotNum) {
+                constexpr uint32_t firstAligned =
+                    (SlotNum % SyncPeriod == 0) ? SlotNum : ((SlotNum / SyncPeriod) + 1) * SyncPeriod;
+                const uint32_t lastAligned = ((prod.tileIndex - 1) / SyncPeriod) * SyncPeriod;
+                if (lastAligned >= firstAligned) {
+                    numPushWait = (lastAligned - firstAligned) / SyncPeriod + 1;
+                }
+            }
+            const uint32_t drainCount = (numPopFree > numPushWait) ? (numPopFree - numPushWait) : 0;
+            for (uint32_t i = 0; i < drainCount; ++i) {
                 prod.template allocate<TileSplitAxis::TILE_NO_SPLIT>();
-            } else {
-                prod.template allocate<TileSplitAxis::TILE_UP_DOWN>();
+            }
+        } else {
+            for (uint32_t i = 0; i < SyncPeriod; ++i) {
+                if constexpr (IsNoSplit) {
+                    prod.template allocate<TileSplitAxis::TILE_NO_SPLIT>();
+                } else {
+                    prod.template allocate<TileSplitAxis::TILE_UP_DOWN>();
+                }
             }
         }
     }

--- a/include/pto/npu/a5/TScatter.hpp
+++ b/include/pto/npu/a5/TScatter.hpp
@@ -179,7 +179,6 @@ PTO_INTERNAL void InitUBBuffer(__ubuf__ T* dst)
         preg = CreatePredicate<T>(num);
         vsts(v_zeros, dst, i * nElemPerVL, distValue, preg);
     }
-    mem_bar(VST_VLD);
     mem_bar(VST_VST);
 }
 

--- a/tests/validate_a5_tpushpop_subblock_dispatch.py
+++ b/tests/validate_a5_tpushpop_subblock_dispatch.py
@@ -8,13 +8,17 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # --------------------------------------------------------------------------------
-"""Validate A5 TPUSH/TPOP sub-block dispatch in the legacy overloads.
+"""Validate A5 TPUSH/TPOP sub-block dispatch and FIFO credit accounting.
 
 The overloads without an explicit ``subBlockId`` must not evaluate
 ``get_subblockid()`` for ``TILE_NO_SPLIT``.  Reading the vector sub-block ID on
 that path changes both AIC and AIV code generation and can deadlock C2V/V2C
 pipes.  Split calls keep the historical implicit-ID behavior, while the
 three-argument overloads continue to forward the caller-provided ID.
+
+Local no-split FIFOs obtain their initial capacity from ``shouldWaitFree`` and
+must drain only unmatched consumer credits at destruction.  Split and GM FIFOs
+retain the explicit constructor/destructor credit protocol.
 """
 
 from pathlib import Path
@@ -74,10 +78,79 @@ def validate_operation(filename: str, operation: str, endpoint: str) -> None:
     assert ", tile, subBlockId)" in explicit, f"{operation}: explicit overload does not forward subBlockId"
 
 
+def expected_local_drain(slot_num: int, transfer_count: int) -> int:
+    sync_period = slot_num if slot_num <= 2 else slot_num // 2
+    producer_waits = sum(
+        tile_index >= slot_num and tile_index % sync_period == 0
+        for tile_index in range(transfer_count)
+    )
+    consumer_frees = transfer_count // sync_period
+    return consumer_frees - producer_waits
+
+
+def implemented_local_drain(slot_num: int, transfer_count: int) -> int:
+    sync_period = slot_num if slot_num <= 2 else slot_num // 2
+    num_pop_free = transfer_count // sync_period
+    if slot_num == 1:
+        num_push_wait = transfer_count - 1 if transfer_count > 0 else 0
+    elif transfer_count > slot_num:
+        first_aligned = (
+            slot_num
+            if slot_num % sync_period == 0
+            else (slot_num // sync_period + 1) * sync_period
+        )
+        last_aligned = (transfer_count - 1) // sync_period * sync_period
+        num_push_wait = (
+            (last_aligned - first_aligned) // sync_period + 1
+            if last_aligned >= first_aligned
+            else 0
+        )
+    else:
+        num_push_wait = 0
+    return max(num_pop_free - num_push_wait, 0)
+
+
+def validate_local_no_split_credit_protocol() -> None:
+    source = (REPO_ROOT / "include" / "pto" / "npu" / "a5" / "TPush.hpp").read_text()
+    normalized = compact(source)
+    condition = (
+        "staticconstexprbooluses_local_no_split_credit_protocol="
+        "IsNoSplit&&(is_c2v_ub||is_v2c_mat||is_v2c_ctrl||is_both);"
+    )
+    assert condition in normalized, "local no-split credit protocol must exclude GM FIFO directions"
+
+    constructor = compact(
+        extract_body(
+            source,
+            r"PTO_INTERNAL\s+explicit\s+TPipe\([^)]*\)\s*:\s*fifo\([^;{]+",
+        )
+    )
+    assert "ifconstexpr(!uses_local_no_split_credit_protocol)" in constructor
+    assert "cons.templatefree<TileSplitAxis::TILE_NO_SPLIT>()" in constructor
+    assert "cons.templatefree<TileSplitAxis::TILE_UP_DOWN>()" in constructor
+
+    destructor = compact(extract_body(source, r"PTO_INTERNAL\s+~TPipe\(\)"))
+    assert "ifconstexpr(uses_local_no_split_credit_protocol)" in destructor
+    assert "constuint32_tnumPopFree=prod.tileIndex/SyncPeriod;" in destructor
+    assert "constuint32_tdrainCount=(numPopFree>numPushWait)?(numPopFree-numPushWait):0;" in destructor
+    assert "prod.templateallocate<TileSplitAxis::TILE_NO_SPLIT>()" in destructor
+    assert "prod.templateallocate<TileSplitAxis::TILE_UP_DOWN>()" in destructor
+
+    for slot_num in (1, 2, 4, 8):
+        for transfer_count in range(0, slot_num * 6 + 1):
+            expected = expected_local_drain(slot_num, transfer_count)
+            implemented = implemented_local_drain(slot_num, transfer_count)
+            assert implemented == expected, (
+                f"credit mismatch: slots={slot_num}, transfers={transfer_count}, "
+                f"implemented={implemented}, expected={expected}"
+            )
+
+
 def main() -> None:
     validate_operation("TPush.hpp", "TPUSH", "pipe.prod.templatepush")
     validate_operation("TPop.hpp", "TPOP", "pipe.cons.templatepop")
-    print("A5 TPUSH/TPOP sub-block dispatch validation passed")
+    validate_local_no_split_credit_protocol()
+    print("A5 TPUSH/TPOP sub-block dispatch and credit validation passed")
 
 
 if __name__ == "__main__":

--- a/tests/validate_a5_tpushpop_subblock_dispatch.py
+++ b/tests/validate_a5_tpushpop_subblock_dispatch.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# --------------------------------------------------------------------------------
+"""Validate A5 TPUSH/TPOP sub-block dispatch in the legacy overloads.
+
+The overloads without an explicit ``subBlockId`` must not evaluate
+``get_subblockid()`` for ``TILE_NO_SPLIT``.  Reading the vector sub-block ID on
+that path changes both AIC and AIV code generation and can deadlock C2V/V2C
+pipes.  Split calls keep the historical implicit-ID behavior, while the
+three-argument overloads continue to forward the caller-provided ID.
+"""
+
+from pathlib import Path
+import re
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def extract_body(source: str, signature: str) -> str:
+    """Return a function body, including braces, using balanced-brace parsing."""
+    match = re.search(signature + r"\s*\{", source)
+    if match is None:
+        raise AssertionError(f"function signature not found: {signature}")
+
+    begin = source.find("{", match.start())
+    depth = 0
+    for pos in range(begin, len(source)):
+        if source[pos] == "{":
+            depth += 1
+        elif source[pos] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[begin : pos + 1]
+    raise AssertionError(f"unterminated function body: {signature}")
+
+
+def compact(source: str) -> str:
+    return re.sub(r"\s+", "", source)
+
+
+def validate_operation(filename: str, operation: str, endpoint: str) -> None:
+    source = (REPO_ROOT / "include" / "pto" / "npu" / "a5" / filename).read_text()
+
+    implicit = extract_body(
+        source,
+        rf"PTO_INTERNAL\s+[^\n]+\s+{operation}_IMPL\(Pipe&\s+pipe,\s+Tile\w+&\s+tile\)",
+    )
+    normalized = compact(implicit)
+    no_split = "ifconstexpr(Split==TileSplitAxis::TILE_NO_SPLIT){"
+    split_else = "}else{"
+    assert no_split in normalized, f"{operation}: missing compile-time TILE_NO_SPLIT branch"
+
+    no_split_body, split_body = normalized.split(no_split, 1)[1].split(split_else, 1)
+    assert "get_subblockid()" not in no_split_body, f"{operation}: TILE_NO_SPLIT evaluates get_subblockid()"
+    assert f"{endpoint}<Tile" in no_split_body and ",tile,0);" in no_split_body, (
+        f"{operation}: TILE_NO_SPLIT must pass literal subBlockId 0"
+    )
+    assert "get_subblockid()" in split_body, f"{operation}: split path lost implicit subBlockId"
+    assert implicit.count("get_subblockid()") == 1, f"{operation}: unexpected implicit subBlockId reads"
+
+    explicit = extract_body(
+        source,
+        rf"PTO_INTERNAL\s+[^\n]+\s+{operation}_IMPL\(Pipe&\s+pipe,\s+Tile\w+&\s+tile,\s+int32_t\s+subBlockId\)",
+    )
+    assert "get_subblockid()" not in explicit, f"{operation}: explicit overload must use its argument"
+    assert ", tile, subBlockId)" in explicit, f"{operation}: explicit overload does not forward subBlockId"
+
+
+def main() -> None:
+    validate_operation("TPush.hpp", "TPUSH", "pipe.prod.templatepush")
+    validate_operation("TPop.hpp", "TPOP", "pipe.cons.templatepop")
+    print("A5 TPUSH/TPOP sub-block dispatch validation passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/validate_a5_tscatter_init_barrier.py
+++ b/tests/validate_a5_tscatter_init_barrier.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# --------------------------------------------------------------------------------
+"""Validate the A5 TSCATTER destination-initialization dependency.
+
+``InitUBBuffer`` initializes the destination with vector stores.  Both indexed
+and mask scatter then update that same destination with vector stores, so the
+required dependency is VST-to-VST.  A VST-to-VLD barrier adds an unrelated
+dependency and changes every mask-scatter kernel's AIV code generation.
+"""
+
+from pathlib import Path
+import re
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def extract_body(source: str, signature: str) -> str:
+    match = re.search(signature + r"\s*\{", source)
+    if match is None:
+        raise AssertionError(f"function signature not found: {signature}")
+
+    begin = source.find("{", match.start())
+    depth = 0
+    for pos in range(begin, len(source)):
+        if source[pos] == "{":
+            depth += 1
+        elif source[pos] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[begin : pos + 1]
+    raise AssertionError(f"unterminated function body: {signature}")
+
+
+def main() -> None:
+    source = (REPO_ROOT / "include" / "pto" / "npu" / "a5" / "TScatter.hpp").read_text()
+    init_body = extract_body(source, r"PTO_INTERNAL\s+void\s+InitUBBuffer\([^)]*\)")
+
+    assert "mem_bar(VST_VLD)" not in init_body, (
+        "TSCATTER destination initialization must not introduce a VST-to-VLD dependency"
+    )
+    assert init_body.count("mem_bar(VST_VST)") == 1, (
+        "TSCATTER destination initialization must keep exactly one VST-to-VST dependency"
+    )
+    assert init_body.rfind("vsts(") < init_body.index("mem_bar(VST_VST)"), (
+        "the VST-to-VST dependency must follow all destination initialization stores"
+    )
+    print("A5 TSCATTER initialization barrier validation passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR restores the A5 local no-split pipe protocol and removes an unrelated load barrier from TScatter initialization.

It contains three focused fixes:

1. Dispatch no-split TPUSH/TPOP with literal `subBlockId = 0`. A no-split FIFO has a single logical lane, while `get_subblockid()` can select another AIV sub-block and address the wrong lane. Split pipes continue to use the implicit hardware sub-block ID.
2. Preserve the local no-split FIFO credit lifecycle. These FIFOs obtain their startup capacity through the `shouldWaitFree` window, so applying the generic constructor pre-credit path double-counts capacity. Their destructor now drains only the outstanding credits derived from actual pushes/frees. GM-backed and split FIFOs keep the existing fixed constructor/destructor protocol.
3. Remove `mem_bar(VST_VLD)` from `TScatter::InitUBBuffer`. Initialization only performs zero-fill stores followed by scatter stores; there is no load dependency for `VST_VLD` to protect. The required `mem_bar(VST_VST)` is deliberately retained to order the zero-fill stores before the following scatter stores.

## Root cause and observed failure

The first two regressions can leave the A5 local producer/consumer swimlane stalled during prefill. The TScatter barrier regression independently caused rank-local non-finite logits on the second decode step. Removing only the unrelated `VST_VLD` barrier made all 36 affected decode AIV binaries match the previously validated behavior again.

## Validation

Structural validation on this exact HEAD, rebased on current `main`:

- `python3 tests/validate_a5_tpushpop_subblock_dispatch.py`
- `python3 tests/validate_a5_tscatter_init_barrier.py`
- `git diff --check origin/main...HEAD`

All passed.

A5 device validation:

- Task `task_20260825_022646_112772923313`, exit 0
- TScatter: 32/32 cases passed, including indexed paths, all mask forms, `int64`, and `uint64`
- TColScatter: 21/21 cases passed

Real-weight end-to-end validation on eight NPUs:

- Task `task_20260825_032443_157876232514`, exit 0
- DeepSeek V4 Flash EP8/TP2, prefill 16, decode 32
- 33/33 sampling points completed
- Every step was finite, greedy, and token-identical across all eight ranks
- Generated continuation: `Paris. It is located in the north-central part of the country, along the Seine River. Paris is known for its rich history, art, fashion, and culture`
- Steady TPOT: 213.861 ms/token, 4.676 token/s per replicated stream

## Cross-repository dependency

The full-model result above uses the coordinated repair stack and is not a pto-isa-only result:

- pto-isa: this PR, HEAD `15554aca`
- PyPTO companion PR: [hw-native-sys/pypto#2509](https://github.com/hw-native-sys/pypto/pull/2509), branch `fix/rebase-main-dsv4-codegen`, HEAD `6a3a8b25`
- pypto-lib companion PR: [hw-native-sys/pypto-lib#1019](https://github.com/hw-native-sys/pypto-lib/pull/1019), branch `fix/rebase-main-dsv4-lib`, HEAD `6b647565`
- simpler runtime was not modified and remained at `93adc386`

The pto-isa structural and operator tests isolate the changes in this repository; the real-weight test validates integration of all three companion changes.

## Risk

The behavior changes are limited to A5. The local-credit special case is gated to local no-split pipe kinds; GM-backed and split flows remain on the existing path. The main residual risk is unusual `SlotNum`/`SyncPeriod` combinations or partially consumed producers, so the drain calculation is based on actual `tileIndex` progress and is covered by the added structural checks plus the full-model run.