### PR TITLE
fix: Restore public header and CPU ST compilation

### DIFF
--- a/include/pto/common/pto_instr_impl.hpp
+++ b/include/pto/common/pto_instr_impl.hpp
@@ -225,6 +225,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include "pto/npu/a5/TLoad.hpp"
 #ifdef __DAV_VEC__
 #include "pto/npu/a5/TCvt.hpp"
+#endif
 #include "pto/npu/a5/TStore.hpp"
 #include "pto/npu/a5/TMrgSort.hpp"
 #include "pto/npu/a5/TMatmul.hpp"
@@ -262,10 +263,10 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include "pto/npu/a5/TRowExpandExpdif.hpp"
 #include "pto/npu/a5/TPartAdd.hpp"
 #include "pto/npu/a5/TPartMul.hpp"
-#include "pto/npu/a5/TPartArgMax.hpp"
 #include "pto/npu/a5/TPartMax.hpp"
-#include "pto/npu/a5/TPartArgMin.hpp"
 #include "pto/npu/a5/TPartMin.hpp"
+#include "pto/npu/a5/TPartArgMax.hpp"
+#include "pto/npu/a5/TPartArgMin.hpp"
 #include "pto/npu/a5/TPow.hpp"
 #include "pto/npu/a5/TQuant.hpp"
 #include "pto/npu/a5/TDeQuant.hpp"
@@ -313,6 +314,10 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #endif // __COSTMODEL
 #endif
 
+#ifdef PTO_NPU_ARCH_A6
+#include "pto/npu/a6/header.hpp"
+#endif
+
 #ifdef PTO_NPU_ARCH_KIRIN9030
 #include "pto/npu/kirin9030/header.hpp"
 #endif
@@ -323,8 +328,11 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include "pto/npu/kirinDev0000/header.hpp"
 #endif
 
-// Async L2 cache prefetch via SDMA CMO. Dispatch through per-architecture
-// wrappers while sharing the common SDMA implementation.
+// Async L2 cache prefetch via SDMA CMO. Dispatched per-arch like other NPU
+// instruction headers; both wrappers pull in the same arch-neutral SDMA-backed
+// implementation (the actual SQE-field differences are handled inside the SDMA
+// helpers via `#ifdef PTO_NPU_ARCH_A5`). Guarded so that costmodel and CPU sim
+// builds pick up their own variant from the blocks below.
 #if defined(__CCE_AICORE__) && !(defined(__CPU_SIM) || defined(__COSTMODEL))
 #ifdef PTO_NPU_ARCH_A2A3
 #include "pto/npu/a2a3/TPrefetchAsync.hpp"

--- a/include/pto/common/type.hpp
+++ b/include/pto/common/type.hpp
@@ -117,8 +117,6 @@ struct int4b_t {
 };
 } // namespace pto
 
-#include <type_traits>
-
 namespace pto {
 enum class TileType {
     Vec,
@@ -423,6 +421,13 @@ enum class TInsertMode : uint8_t {
 #endif
 
 enum class Coalesce : uint8_t { Row = 0, Elem = 1 };
+
+struct MrgSortExecutedNumList {
+    uint16_t mrgSortList0;
+    uint16_t mrgSortList1;
+    uint16_t mrgSortList2;
+    uint16_t mrgSortList3;
+};
 
 namespace GlobalTensorDim {
 constexpr int DIM_0 = 0;

--- a/include/pto/cpu/TPop.hpp
+++ b/include/pto/cpu/TPop.hpp
@@ -45,7 +45,7 @@ PTO_INTERNAL void TPOP_IMPL(Pipe& pipe, TileCons& tile)
 template <
     typename TileCons, typename Pipe,
     std::enable_if_t<(is_tile_data_v<TileCons> || is_conv_tile_v<TileCons>) && !is_global_data_v<TileCons>, int> = 0>
-PTO_INTERNAL void TPOP_REVERSED_IMPL(TileCons& tile, Pipe& pipe)
+PTO_INTERNAL void TPOP_IMPL(TileCons& tile, Pipe& pipe)
 {
     TPOP_IMPL<Pipe, TileCons, TileSplitAxis::TILE_NO_SPLIT>(pipe, tile);
 }

--- a/tests/cpu/st/testcase/ttrace/main.cpp
+++ b/tests/cpu/st/testcase/ttrace/main.cpp
@@ -50,7 +50,7 @@ protected:
     }
 };
 
-TEST_F(TTraceTest, CapturesZeroOperandAndBasicTileInstructions)
+TEST_F(TTraceTest, CapturesBasicTileInstructions)
 {
     if (!pto::cpu_sim::kInstructionTraceEnabled) {
         GTEST_SKIP() << "PTO_CPU_SIM_TRACE_MODE is disabled for this build.";
@@ -67,33 +67,26 @@ TEST_F(TTraceTest, CapturesZeroOperandAndBasicTileInstructions)
     FillLinear(src1, 2.0f);
     pto::cpu_sim::ResetInstructionTrace();
 
-    pto::TSYNC<pto::Op::TADD>();
     pto::TADD(dst, src0, src1);
     pto::TDIV(dst, src0, src1);
 
     const auto trace = pto::cpu_sim::CopyInstructionTraceRecords();
-    ASSERT_EQ(trace.size(), 3u);
+    ASSERT_EQ(trace.size(), 2u);
 
-    EXPECT_EQ(trace[0].opcode, "TSYNC");
+    EXPECT_EQ(trace[0].opcode, "TADD");
     EXPECT_EQ(trace[0].block_idx, 7u);
     EXPECT_EQ(trace[0].sequence_id, 0u);
-    EXPECT_TRUE(trace[0].input_tiles.empty());
-    EXPECT_TRUE(trace[0].scalar_inputs.empty());
-    EXPECT_TRUE(trace[0].output_tiles.empty());
+    ASSERT_EQ(trace[0].input_tiles.size(), 2u);
+    ASSERT_EQ(trace[0].output_tiles.size(), 1u);
+    EXPECT_EQ(trace[0].input_tiles[0].address, TraceAddress(src0));
+    EXPECT_EQ(trace[0].input_tiles[1].address, TraceAddress(src1));
+    EXPECT_EQ(trace[0].output_tiles[0].address, TraceAddress(dst));
+    EXPECT_EQ(trace[0].output_tiles[0].shape, (std::vector<int64_t>{2, 32}));
 
-    EXPECT_EQ(trace[1].opcode, "TADD");
+    EXPECT_EQ(trace[1].opcode, "TDIV");
     EXPECT_EQ(trace[1].sequence_id, 1u);
     ASSERT_EQ(trace[1].input_tiles.size(), 2u);
     ASSERT_EQ(trace[1].output_tiles.size(), 1u);
-    EXPECT_EQ(trace[1].input_tiles[0].address, TraceAddress(src0));
-    EXPECT_EQ(trace[1].input_tiles[1].address, TraceAddress(src1));
-    EXPECT_EQ(trace[1].output_tiles[0].address, TraceAddress(dst));
-    EXPECT_EQ(trace[1].output_tiles[0].shape, (std::vector<int64_t>{2, 32}));
-
-    EXPECT_EQ(trace[2].opcode, "TDIV");
-    EXPECT_EQ(trace[2].sequence_id, 2u);
-    ASSERT_EQ(trace[2].input_tiles.size(), 2u);
-    ASSERT_EQ(trace[2].output_tiles.size(), 1u);
 
     std::ostringstream json;
     pto::cpu_sim::DumpInstructionTraceJson(json);


### PR DESCRIPTION
The A5 `__DAV_VEC__` guard remained open after the `TCvt` include, so
subsequent A5 implementations and the CPU simulator block were nested under
the wrong condition and the outer header guard was left unterminated. The same
interface cleanup also removed `MrgSortExecutedNumList` while merge-sort APIs
and implementations still required it. The cleanup left the CPU reversed
`TPOP` wrapper calling a name that no longer matched its implementation and
left a trace test using the removed public `TSYNC` API.

## Summary
- Close `__DAV_VEC__` immediately after the A5 `TCvt` implementation include
- Restore visibility of subsequent A5 and CPU simulator implementation headers
- Restore `MrgSortExecutedNumList` in the common type definitions
- Remove the duplicated `type_traits` include to match the GitCode header
- Align A5 merge-sort includes and async-prefetch documentation with GitCode
- Restore the A6 instruction implementation entry removed by stale replay
- Restore the GitCode-compatible reversed `TPOP_IMPL` overload for CPU SIM
- Remove the stale public `TSYNC` call from CPU trace coverage

## Testing
- [x] All 3 header preprocessing checks pass for CPU SIM, A2/A3, and A5
- [x] Diagnostic CPU SIM build no longer reports the two target header errors
- [x] CPU SIM and A6 instruction header preprocessing checks pass
- [x] Both modified common headers match GitCode `upstream/master` byte for byte
- [x] GCC 15 builds the complete CPU ST target set
- [x] All 16 `tpushpop` tests pass, including multicore C2V and V2C coverage
- [x] Clang-format dry-run and Git diff validation pass

Fixes #270
