### PR TITLE
fix(core): Align integer traits with the GitCode pre-sync baseline

### DIFF
--- a/include/pto/common/arch_capability.hpp
+++ b/include/pto/common/arch_capability.hpp
@@ -333,12 +333,6 @@ PTO_INTERNAL constexpr bool IsFloatingPoint()
 }
 
 template <typename T>
-PTO_INTERNAL constexpr bool IsInteger()
-{
-    return IsInt8<T>() || IsInt16<T>() || IsInt32<T>() || IsInt64<T>() || IsInt4<T>();
-}
-
-template <typename T>
 PTO_INTERNAL constexpr bool IsSInteger()
 {
     return IsSInt8<T>() || IsSInt16<T>() || IsSInt32<T>() || IsSInt64<T>();
@@ -348,6 +342,12 @@ template <typename T>
 PTO_INTERNAL constexpr bool IsUInteger()
 {
     return IsUInt8<T>() || IsUInt16<T>() || IsUInt32<T>() || IsUInt64<T>();
+}
+
+template <typename T>
+PTO_INTERNAL constexpr bool IsInteger()
+{
+    return IsSInteger<T>() || IsUInteger<T>();
 }
 
 template <typename T>


### PR DESCRIPTION
Align the capability header with the parent of GitCode commit 9a4d75c45,
before its ND2NZ update. This gives the next synchronization the expected
IsInteger definition without importing the ND2NZ capability additions early.
Regenerate the synchronization branch from GitCode after this fix lands;
the existing PR https://github.com/hw-native-sys/pto-isa/pull/300 header patch conflicts with this corrected baseline.

## Summary

- Move IsInteger after IsSInteger and IsUInteger and combine their results
- Match the complete pre-ND2NZ GitCode header, including its behavior where
  int4b_t is not classified as an integer

## Testing

- [x] All 10 compile-time type assertions pass with GCC 15
- [x] Header matches the parent of GitCode 9a4d75c45 byte for byte
- [x] Three-way replay of the original GitCode ND2NZ header update succeeds
  and matches its resulting header with one IsInteger definition
- [x] Pre-commit checks pass for the changed file
- [x] Independent OAT scan passes for the complete staged set of 1 file
- [x] git diff --cached --check passes